### PR TITLE
feat(back): add ModelMapper config and mappers for user, comment, post, and topic

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/configuration/ModelMapperConfig.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/configuration/ModelMapperConfig.java
@@ -1,0 +1,17 @@
+package com.openclassrooms.mddapi.configuration;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setSkipNullEnabled(true);
+        return mapper;
+    }
+
+}

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/comment/CommentResponseDTO.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/comment/CommentResponseDTO.java
@@ -11,11 +11,17 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class CommentResponseDTO {
 
-    final private Long id;
+    private final Long id;
 
-    final private String username;
+    @JsonProperty("post_id")
+    private final Long postId;
 
-    final private String content;
+    @JsonProperty("user_id")
+    private final Long userId;
+
+    private final String username;
+
+    private final String content;
 
     @JsonProperty("created_at")
     @JsonFormat(pattern = "yyyy/MM/dd")

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/post/PostResponseDTO.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/post/PostResponseDTO.java
@@ -13,22 +13,22 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostResponseDTO {
 
-    final private Long id;
+    private final Long id;
 
     @JsonProperty("topic_id")
-    final private Long topicId;
+    private final Long topicId;
 
     @JsonProperty("user_id")
-    final private Long userId;
+    private final Long userId;
 
-    final private String title;
+    private final String title;
 
-    final private String content;
+    private final String content;
 
     @JsonProperty("created_at")
     @JsonFormat(pattern = "yyyy/MM/dd")
     final private LocalDateTime createdAt;
 
-    final private List<CommentResponseDTO> comments;
+    private final List<CommentResponseDTO> comments;
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/topic/TopicDTO.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/topic/TopicDTO.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TopicDTO {
 
-    final Long id;
+    private final Long id;
 
-    final private String title;
+    private final String title;
 
-    final private String description;
+    private final String description;
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/user/UpdateUserDTO.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/user/UpdateUserDTO.java
@@ -1,0 +1,20 @@
+package com.openclassrooms.mddapi.dto.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import lombok.Data;
+
+@Data
+public class UpdateUserDTO {
+
+    private String username;
+
+    @Email
+    private String email;
+
+    private String name;
+
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_]).{8,}$")
+    private String password;
+
+}

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/CommentMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/CommentMapper.java
@@ -1,0 +1,43 @@
+package com.openclassrooms.mddapi.mapper;
+
+import com.openclassrooms.mddapi.dto.comment.CommentRequestDTO;
+import com.openclassrooms.mddapi.dto.comment.CommentResponseDTO;
+import com.openclassrooms.mddapi.model.Comment;
+import com.openclassrooms.mddapi.model.Post;
+import com.openclassrooms.mddapi.model.User;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class CommentMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public CommentMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    /** Convert Comment entity to CommentResponseDTO */
+    public CommentResponseDTO toCommentResponseDTO(Comment comment) {
+        return modelMapper.map(comment, CommentResponseDTO.class);
+    }
+
+    /** Convert CommentRequestDTO to Comment entity */
+    public Comment toCommentEntity(CommentRequestDTO commentRequestDTO, User user, Post post) {
+        Comment comment = modelMapper.map(commentRequestDTO, Comment.class);
+        comment.setUser(user);
+        comment.setPost(post);
+        return comment;
+    }
+
+    /** Converts a list of comment entities to a list of CommentResponseDTOs */
+    public List<CommentResponseDTO> toCommentResponseDTOList(List<Comment> comments) {
+        return comments.stream().map(this::toCommentResponseDTO).collect(Collectors.toList());
+    }
+
+}

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/PostMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/PostMapper.java
@@ -1,0 +1,42 @@
+package com.openclassrooms.mddapi.mapper;
+
+import com.openclassrooms.mddapi.dto.post.PostRequestDTO;
+import com.openclassrooms.mddapi.dto.post.PostResponseDTO;
+import com.openclassrooms.mddapi.model.Post;
+import com.openclassrooms.mddapi.model.Topic;
+import com.openclassrooms.mddapi.model.User;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class PostMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public PostMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    /** Convert Post entity to PostResponseDTO */
+    public PostResponseDTO toPostResponseDTO(Post post) {
+        return modelMapper.map(post, PostResponseDTO.class);
+    }
+
+    /** Convert PostRequestDTO to Post entity */
+    public Post toPostEntity(PostRequestDTO postRequestDTO, User user, Topic topic) {
+        Post post = modelMapper.map(postRequestDTO, Post.class);
+        post.setUser(user);
+        post.setTopic(topic);
+        return post;
+    }
+
+    /** Converts a list of post entities to a list of PostResponseDTOs */
+    public List<PostResponseDTO> toPostResponseDTOList(List<Post> posts) {
+        return posts.stream().map(this::toPostResponseDTO).collect(Collectors.toList());
+    }
+}

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/TopicMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/TopicMapper.java
@@ -1,0 +1,32 @@
+package com.openclassrooms.mddapi.mapper;
+
+import com.openclassrooms.mddapi.dto.topic.TopicDTO;
+import com.openclassrooms.mddapi.model.Topic;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class TopicMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public TopicMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    /** Convert Topic entity to TopicDTO */
+    public TopicDTO toTopicDTO(Topic topic) {
+        return modelMapper.map(topic, TopicDTO.class);
+    }
+
+    /** Converts a list of topic entities to a list of TopicDTOs */
+    public List<TopicDTO> toTopicDTOList(List<Topic> topics) {
+        return topics.stream().map(this::toTopicDTO).collect(Collectors.toList());
+    }
+
+}

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/UserMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/UserMapper.java
@@ -1,0 +1,36 @@
+package com.openclassrooms.mddapi.mapper;
+
+import com.openclassrooms.mddapi.dto.user.RegisterRequestDTO;
+import com.openclassrooms.mddapi.dto.user.UpdateUserDTO;
+import com.openclassrooms.mddapi.dto.user.UserDTO;
+import com.openclassrooms.mddapi.model.User;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    private final ModelMapper modelMapper;
+
+    @Autowired
+    public UserMapper(ModelMapper modelMapper) {
+        this.modelMapper = modelMapper;
+    }
+
+    /** Convert User entity to UserDTO */
+    public UserDTO toUserDTO(User user) {
+        return modelMapper.map(user, UserDTO.class);
+    }
+
+    /** Convert RegisterRequestDTO to User entity */
+    public User toUserEntity(RegisterRequestDTO registerRequestDTO) {
+        return modelMapper.map(registerRequestDTO, User.class);
+    }
+
+    /** Update existing User entity with fields from UpdateUserDTO */
+    public void updateUserEntityFromDTO(UpdateUserDTO updateUserDTO, User existingUser) {
+        modelMapper.map(updateUserDTO, existingUser);
+    }
+
+}


### PR DESCRIPTION
- Add UserMapper and UpdateUserDTO for user profile update handling
- Add CommentMapper, PostMapper, and TopicMapper for respective DTO-entity conversions
- Add ModelMapperConfig to provide a globally configured ModelMapper bean with skipNullEnabled=true to support partial updates