### PR TITLE
feat(back): add package-info files to javadoc

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/MddApiApplication.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/MddApiApplication.java
@@ -3,6 +3,10 @@ package com.openclassrooms.mddapi;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+/**
+ * Main entry point for the MDD API Spring Boot application.
+ * It bootstraps and launches the application context.
+ */
 @SpringBootApplication
 public class MddApiApplication {
 

--- a/back/src/main/java/com/openclassrooms/mddapi/annotation/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/annotation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Custom annotations used across the MDD API application.
+ */
+package com.openclassrooms.mddapi.annotation;

--- a/back/src/main/java/com/openclassrooms/mddapi/configuration/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/configuration/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Configuration classes for application setup, including AppConfig,
+ * JwtProperties, ModelMapperConfig, OpenAPIConfig, and SecurityConfig.
+ */
+package com.openclassrooms.mddapi.configuration;

--- a/back/src/main/java/com/openclassrooms/mddapi/controller/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/controller/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * REST controller classes exposing API endpoints to handle client requests.
+ */
+package com.openclassrooms.mddapi.controller;

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/comment/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/comment/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data Transfer Objects related to comments for API request and response handling.
+ */
+package com.openclassrooms.mddapi.dto.comment;

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/post/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/post/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data Transfer Objects related to posts for API request and response handling.
+ */
+package com.openclassrooms.mddapi.dto.post;

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/topic/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/topic/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data Transfer Objects related to topics for API request and response handling.
+ */
+package com.openclassrooms.mddapi.dto.topic;

--- a/back/src/main/java/com/openclassrooms/mddapi/dto/user/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/dto/user/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Data Transfer Objects related to users for API request and response handling.
+ */
+package com.openclassrooms.mddapi.dto.user;

--- a/back/src/main/java/com/openclassrooms/mddapi/exception/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/exception/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Custom exception classes for handling application-specific errors.
+ */
+package com.openclassrooms.mddapi.exception;

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Mapper classes responsible for converting between entities and DTOs.
+ */
+package com.openclassrooms.mddapi.mapper;

--- a/back/src/main/java/com/openclassrooms/mddapi/model/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/model/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Core domain model classes representing the main entities of the application,
+ * such as User, Post, Comment, and Topic.
+ */
+package com.openclassrooms.mddapi.model;

--- a/back/src/main/java/com/openclassrooms/mddapi/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Root package for the MDD API application.
+ * Contains core classes and configuration for the social network MDD back-end.
+ */
+package com.openclassrooms.mddapi;

--- a/back/src/main/java/com/openclassrooms/mddapi/repository/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/repository/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Repository interfaces for data access and persistence operations.
+ */
+package com.openclassrooms.mddapi.repository;

--- a/back/src/main/java/com/openclassrooms/mddapi/response/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/response/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Classes representing standard API response structures such as
+ * authentication responses, error messages, posts, and topics.
+ */
+package com.openclassrooms.mddapi.response;

--- a/back/src/main/java/com/openclassrooms/mddapi/security/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/security/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Security-related classes including JWT services, custom user details,
+ * and user details service implementations.
+ */
+package com.openclassrooms.mddapi.security;

--- a/back/src/main/java/com/openclassrooms/mddapi/service/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/service/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Service layer classes containing business logic for the application.
+ */
+package com.openclassrooms.mddapi.service;

--- a/back/src/main/java/com/openclassrooms/mddapi/validator/package-info.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/validator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Custom validators for input validation beyond standard constraints.
+ */
+package com.openclassrooms.mddapi.validator;


### PR DESCRIPTION
- Add package-info.java files to all packages
- Provide brief descriptions for each package to improve documentation clarity