### PR TITLE
feat(back): simplify JWTService and AuthController by removing refresh token logic

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/configuration/SecurityConfig.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/configuration/SecurityConfig.java
@@ -49,7 +49,6 @@ public class SecurityConfig {
                                 "/",
                                 "/api/auth/login",
                                 "/api/auth/register",
-                                "/api/auth/refresh",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",

--- a/back/src/main/java/com/openclassrooms/mddapi/controller/AuthController.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/controller/AuthController.java
@@ -2,26 +2,18 @@ package com.openclassrooms.mddapi.controller;
 
 import com.openclassrooms.mddapi.dto.user.LoginRequestDTO;
 import com.openclassrooms.mddapi.dto.user.RegisterRequestDTO;
-import com.openclassrooms.mddapi.exception.JwtValidationException;
 import com.openclassrooms.mddapi.response.AuthResponse;
-import com.openclassrooms.mddapi.response.ErrorResponse;
 import com.openclassrooms.mddapi.security.JWTService;
 import com.openclassrooms.mddapi.service.UserService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,9 +21,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controller for user authentication and authorization operations,
- * including registration, login, token refresh, and logout.
+ * including registration and login.
  */
-@Tag(name = "Authentication", description = "Endpoints for user authentication and token management")
+@Tag(name = "Authentication", description = "Endpoints for user authentication")
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
@@ -49,24 +41,23 @@ public class AuthController {
     /**
      * Registers a new user and immediately logs them in.
      *
-     * @param registerRequestDTO the registration details (username, email, name, password)
-     * @param httpServletResponse the HTTP response, used to set refresh token cookie
+     * @param registerRequestDTO the registration details (username, email and password)
      * @return the access token for the newly registered user
      */
-    @Operation(summary = "Register new user", description = "Registers a new user and returns an access token with a refresh token cookie.")
+    @Operation(summary = "Register new user", description = "Registers a new user and returns an access token.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User registered and logged in successfully"),
             @ApiResponse(responseCode = "400", description = "Invalid registration data"),
             @ApiResponse(responseCode = "409", description = "Username or email already in use")
     })
     @PostMapping("/register")
-    public ResponseEntity<AuthResponse> register(@RequestBody @Valid RegisterRequestDTO registerRequestDTO, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<AuthResponse> register(@RequestBody @Valid RegisterRequestDTO registerRequestDTO) {
         userService.registerUser(registerRequestDTO);
         // direct login after register
         Authentication authentication = authenticationManager
                 .authenticate(new UsernamePasswordAuthenticationToken(registerRequestDTO.getUsername(), registerRequestDTO.getPassword()));
 
-        String accessToken = jwtService.generateTokensAndSetCookie(authentication, httpServletResponse);
+        String accessToken = jwtService.generateToken(authentication);
         return ResponseEntity.ok(new AuthResponse(accessToken));
     }
 
@@ -74,60 +65,21 @@ public class AuthController {
      * Authenticates a user by username or email and password, returning a JWT access token.
      *
      * @param loginRequestDTO the login credentials (username or email, and password)
-     * @param httpServletResponse the HTTP response, used to set refresh token cookie
      * @return the access token for the authenticated user
      */
-    @Operation(summary = "User login", description = "Authenticates user and returns an access token with a refresh token cookie.")
+    @Operation(summary = "User login", description = "Authenticates user and returns an access token.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User logged in successfully"),
             @ApiResponse(responseCode = "401", description = "Invalid credentials or unauthorized")
     })
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequestDTO loginRequestDTO, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequestDTO loginRequestDTO) {
         // login with the credential provided
         Authentication authentication = authenticationManager
                 .authenticate((new UsernamePasswordAuthenticationToken(loginRequestDTO.getUsernameOrEmail(), loginRequestDTO.getPassword())));
 
-        String accessToken = jwtService.generateTokensAndSetCookie(authentication, httpServletResponse);
+        String accessToken = jwtService.generateToken(authentication);
         return ResponseEntity.ok(new AuthResponse(accessToken));
-    }
-
-    /**
-     * Refreshes the access token using a valid refresh token stored in an HttpOnly cookie.
-     *
-     * @param httpServletRequest the HTTP request containing the refresh token cookie
-     * @param httpServletResponse the HTTP response to set new tokens and cookies
-     * @return the new access token or error if refresh token is invalid
-     */
-    @Operation(summary = "Refresh JWT token", description = "Refreshes the access token using a valid refresh token cookie.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Access token refreshed successfully"),
-            @ApiResponse(responseCode = "401", description = "Invalid or missing refresh token")
-    })
-    @PostMapping("/refresh")
-    public ResponseEntity<Object> refreshToken(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
-        try {
-            Cookie[] cookies = httpServletRequest.getCookies();
-            String newAccessToken = jwtService.refreshToken(httpServletResponse, cookies);
-            return ResponseEntity.ok(new AuthResponse(newAccessToken));
-        } catch (JwtValidationException e) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse("Invalid token!"));
-        }
-    }
-
-    /**
-     * Logs out the current user by clearing the refresh token cookie.
-     *
-     * @param httpServletResponse the HTTP response to clear the refresh token cookie
-     * @return HTTP 204 No Content response
-     */
-    @Operation(summary = "Logout user", description = "Logs out the user by clearing the refresh token cookie.")
-    @ApiResponse(responseCode = "204", description = "User logged out successfully")
-    @PostMapping("/logout")
-    public ResponseEntity<Void> logout(HttpServletResponse httpServletResponse) {
-        // clears the refresh token cookie on logout
-        jwtService.addHttpOnlyCookie(httpServletResponse, "", 0);
-        return ResponseEntity.noContent().build(); // HTTP 204 No Content
     }
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/security/JWTService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/security/JWTService.java
@@ -1,125 +1,53 @@
 package com.openclassrooms.mddapi.security;
 
+import com.openclassrooms.mddapi.configuration.JwtProperties;
 import com.openclassrooms.mddapi.exception.JwtGenerationException;
-import com.openclassrooms.mddapi.exception.JwtValidationException;
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jwt.*;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
 /**
- * Service responsible for generating, validating, and refreshing JWT tokens.
- * <p>
- * Manages access and refresh tokens, sets refresh tokens as HTTP-only cookies,
- * and authenticates users based on refresh tokens.
- * </p>
+ * Service responsible for generating JWT tokens.
  */
 @Service
 public class JWTService {
 
     private final JwtEncoder jwtEncoder;
-    private final JwtDecoder jwtDecoder;
-    private final UserDetailsServiceImpl userDetailsServiceImpl;
 
-    private static final int ACCESS_TOKEN_DURATION = 15 * 60; // 15 minutes
-    private static final int REFRESH_TOKEN_DURATION = 7 * 24 * 60 * 60; // 7 days
-    private static final ChronoUnit TOKEN_UNIT = ChronoUnit.SECONDS;
+    private final JwtProperties jwtProperties;
 
-    public JWTService(JwtEncoder jwtEncoder, JwtDecoder jwtDecoder, UserDetailsServiceImpl userDetailsServiceImpl) {
+    public JWTService(JwtEncoder jwtEncoder, JwtProperties jwtProperties) {
         this.jwtEncoder = jwtEncoder;
-        this.jwtDecoder = jwtDecoder;
-        this.userDetailsServiceImpl = userDetailsServiceImpl;
+        this.jwtProperties = jwtProperties;
     }
 
-    public String generateToken(Authentication authentication, long duration, ChronoUnit unit, String tokenType) {
+    public String generateToken(Authentication authentication) {
         Instant now = Instant.now();
         String subject = authentication.getName();
 
-        JwtClaimsSet jwtClaimsSet = JwtClaimsSet.builder()
+        JwtClaimsSet claims = JwtClaimsSet.builder()
                 .issuer("self")
                 .issuedAt(now)
-                .expiresAt(now.plus(duration, unit))
+                .expiresAt(now.plus(1, ChronoUnit.DAYS))
                 .subject(subject)
                 .build();
 
         JwtEncoderParameters jwtEncoderParameters = JwtEncoderParameters
-                .from(JwsHeader.with(MacAlgorithm.HS256).build(), jwtClaimsSet);
+                .from(JwsHeader.with(MacAlgorithm.HS256).build(), claims);
 
         try {
             return this.jwtEncoder.encode(jwtEncoderParameters).getTokenValue();
         }
         catch (Exception e) {
-            throw new JwtGenerationException(tokenType + " token generation failed. Please try again later.");
+            throw new JwtGenerationException("Token generation failed. Please try again later.");
         }
-    }
-
-    public String generateAccessToken(Authentication authentication) {
-        return generateToken(authentication, ACCESS_TOKEN_DURATION, TOKEN_UNIT, "Access");
-    }
-
-    public String generateRefreshToken(Authentication authentication) {
-        return generateToken(authentication, REFRESH_TOKEN_DURATION, TOKEN_UNIT, "Refresh");
-    }
-
-    public void addHttpOnlyCookie(HttpServletResponse httpServletResponse, String value, int durationSeconds) {
-        Cookie cookie = new Cookie("refresh_token", value);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(durationSeconds);
-        httpServletResponse.addCookie(cookie);
-    }
-
-    public String generateTokensAndSetCookie(Authentication authentication, HttpServletResponse httpServletResponse) {
-        String accessToken = generateAccessToken(authentication);
-        String refreshToken = generateRefreshToken(authentication);
-
-        // set refresh token as httpOnly cookie only
-        addHttpOnlyCookie(httpServletResponse, refreshToken, REFRESH_TOKEN_DURATION);
-
-        // return access token to send in response body
-        return accessToken;
-    }
-
-    public String validateAndGetUsername(String token) {
-        try {
-            Jwt jwt = jwtDecoder.decode(token);
-            return jwt.getSubject();
-        } catch (JwtException e) {
-            throw new JwtValidationException("Invalid token!");
-        }
-    }
-
-    public Authentication authenticateRefreshToken(String refreshToken) {
-        String username = validateAndGetUsername(refreshToken);
-        UserDetails userDetails = userDetailsServiceImpl.loadUserByUsername(username);
-        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-    }
-
-    public String extractRefreshTokenFromCookies(Cookie[] cookies) {
-        if (cookies == null) {
-            throw new JwtValidationException("Refresh token is missing");
-        }
-
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh_token")) {
-                return cookie.getValue();
-            }
-        }
-        throw new JwtValidationException("Refresh token is missing");
-    }
-
-    public String refreshToken(HttpServletResponse httpServletResponse, Cookie[] cookies) {
-        String refreshToken = extractRefreshTokenFromCookies(cookies);
-        Authentication authentication = authenticateRefreshToken(refreshToken);
-        return generateTokensAndSetCookie(authentication, httpServletResponse);
     }
 
 }


### PR DESCRIPTION
- Remove refresh and logout endpoints in AuthController
- Remove cookie and refresh token handling
- Remove HttpServletResponse usage for setting refresh token cookies
- Simplify JWT token generation in JWTService