### PR TITLE
fix(back): enforce global uniqueness for post titles

### DIFF
--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/CommentMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/CommentMapper.java
@@ -52,6 +52,7 @@ public class CommentMapper {
 
     /** Converts a list of comment entities to a list of CommentResponseDTOs */
     public List<CommentResponseDTO> toCommentResponseDTOList(List<Comment> comments) {
+        // map each comment entity to a CommentResponseDTO and collect into a list
         return comments.stream().map(this::toCommentResponseDTO).collect(Collectors.toList());
     }
 

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/PostMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/PostMapper.java
@@ -28,19 +28,24 @@ public class PostMapper {
     /** Convert Post entity to PostResponseDTO */
     public PostResponseDTO toPostResponseDTO(Post post) {
         PostResponseDTO postResponseDTO = modelMapper.map(post, PostResponseDTO.class);
+
+        // set user information if available
         if (post.getUser() != null) {
             postResponseDTO.setUsername(post.getUser().getUsername());
             postResponseDTO.setUserId(post.getUser().getId());
         }
 
+        // set topic information if available
         if (post.getTopic() != null) {
             postResponseDTO.setTopicId(post.getTopic().getId());
             postResponseDTO.setTopicTitle(post.getTopic().getTitle());
         }
 
+        // map comments associated with the post
         if (post.getComments() != null) {
             postResponseDTO.setComments(commentMapper.toCommentResponseDTOList(post.getComments()));
         }
+
         return postResponseDTO;
     }
 
@@ -54,6 +59,7 @@ public class PostMapper {
 
     /** Converts a list of post entities to a list of PostResponseDTOs */
     public List<PostResponseDTO> toPostResponseDTOList(List<Post> posts) {
+        // map each post entity to a PostResponseDTO and collect into a list
         return posts.stream().map(this::toPostResponseDTO).collect(Collectors.toList());
     }
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/TopicMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/TopicMapper.java
@@ -29,6 +29,7 @@ public class TopicMapper {
 
     /** Converts a list of topic entities to a list of TopicDTOs */
     public List<TopicDTO> toTopicDTOList(List<Topic> topics) {
+        // map each topic entity to TopicDTO and collect into a list
         return topics.stream().map(this::toTopicDTO).collect(Collectors.toList());
     }
 

--- a/back/src/main/java/com/openclassrooms/mddapi/mapper/UserMapper.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/mapper/UserMapper.java
@@ -48,7 +48,7 @@ public class UserMapper {
 
         if (user.getTopics() != null && !user.getTopics().isEmpty()) {
             List<TopicDTO> topicDTOs = topicMapper.toTopicDTOList(user.getTopics());
-            userDTO.setTopics(topicDTOs);
+            userDTO.setTopics(topicDTOs); // include subscribed topics in DTO
         }
         return userDTO;
     }

--- a/back/src/main/java/com/openclassrooms/mddapi/model/Comment.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/model/Comment.java
@@ -26,11 +26,11 @@ public class Comment {
 
     @ManyToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false)
-    private User user;
+    private User user; // author of the comment
 
     @ManyToOne
     @JoinColumn(name = "post_id", referencedColumnName = "id", nullable = false)
-    private Post post;
+    private Post post; // post that this comment belongs to
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/back/src/main/java/com/openclassrooms/mddapi/model/Post.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/model/Post.java
@@ -40,7 +40,7 @@ public class Post {
     private User user;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
+    private List<Comment> comments = new ArrayList<>(); // comments belonging to this post
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/back/src/main/java/com/openclassrooms/mddapi/model/Topic.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/model/Topic.java
@@ -31,10 +31,10 @@ public class Topic {
     private String description;
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Post> posts = new ArrayList<>();
+    private List<Post> posts = new ArrayList<>(); // posts belonging to this topic
 
     @ManyToMany(mappedBy = "topics")
-    private List<User> users = new ArrayList<>();
+    private List<User> users = new ArrayList<>(); // users subscribed to this topic
 
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)

--- a/back/src/main/java/com/openclassrooms/mddapi/model/User.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/model/User.java
@@ -45,7 +45,7 @@ public class User {
             joinColumns = @JoinColumn(name = "user_id"),
             inverseJoinColumns = @JoinColumn(name = "topic_id")
     )
-    private List<Topic> topics = new ArrayList<>();
+    private List<Topic> topics = new ArrayList<>(); // topics the user is subscribed to
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/back/src/main/java/com/openclassrooms/mddapi/repository/CommentRepository.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/repository/CommentRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
  */
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByPostId(Long postId);
+    List<Comment> findByPostId(Long postId); // fetch all comments associated with a specific post
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/repository/PostRepository.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/repository/PostRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByTopicId(Long topicId);
-    boolean existsByTitleAndTopicId(String title, Long topicId);
+    boolean existsByTitle(String title); // check if a post with the given title already exists
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/security/JWTService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/security/JWTService.java
@@ -39,6 +39,7 @@ public class JWTService {
                 .subject(subject)
                 .build();
 
+        // create encoder parameters with header and claims for token generation
         JwtEncoderParameters jwtEncoderParameters = JwtEncoderParameters
                 .from(JwsHeader.with(MacAlgorithm.HS256).build(), claims);
 

--- a/back/src/main/java/com/openclassrooms/mddapi/security/UserDetailsServiceImpl.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/security/UserDetailsServiceImpl.java
@@ -27,9 +27,10 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String usernameOrEmail) throws UsernameNotFoundException {
-            User user = userRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail)
-                    .orElseThrow(() -> new UsernameNotFoundException("User not found!"));
-            return new CustomUserDetails(user);
+        // find user by username or email, throw if not found
+        User user = userRepository.findByUsernameOrEmail(usernameOrEmail, usernameOrEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found!"));
+        return new CustomUserDetails(user);
     }
 
 }

--- a/back/src/main/java/com/openclassrooms/mddapi/service/CommentService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/service/CommentService.java
@@ -44,11 +44,13 @@ public class CommentService {
 
     @Transactional
     public CommentResponseDTO saveComment(Long userId, Long postId, CommentRequestDTO commentRequestDTO) {
+        // fetch user and post, throw exception if not found
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("User not found!"));
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException("Post not found!"));
 
+        // map DTO to entity and associate with user and post
         Comment comment = commentMapper.toCommentEntity(commentRequestDTO);
         comment.setUser(user);
         comment.setPost(post);
@@ -59,8 +61,11 @@ public class CommentService {
 
     @Transactional (readOnly = true)
     public List<CommentResponseDTO> getAllCommentsForPost(Long postId) {
+        // ensure the post exists
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException("Post not found!"));
+
+        // fetch all comments for the post and map to DTOs
         List<Comment> comments = commentRepository.findByPostId(postId);
         return commentMapper.toCommentResponseDTOList(comments);
     }

--- a/back/src/main/java/com/openclassrooms/mddapi/service/PostService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/service/PostService.java
@@ -47,16 +47,18 @@ public class PostService {
 
     @Transactional
     public PostResponseDTO savePost(Long userId, PostRequestDTO postRequestDTO) {
+        // fetch the user and topic, throw if not found
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("User not found!"));
         Topic topic = topicRepository.findById(postRequestDTO.getTopicId())
                 .orElseThrow(() -> new TopicNotFoundException("Topic not found!"));
 
-        // check for duplicate title in the same topic
-        if (postRepository.existsByTitleAndTopicId(postRequestDTO.getTitle(), topic.getId())) {
+        // global duplicate title check
+        if (postRepository.existsByTitle(postRequestDTO.getTitle())) {
             throw new DuplicateFieldValidationException("A post with this title already exists!");
         }
 
+        // map DTO to entity and associate user and topic
         Post post = postMapper.toPostEntity(postRequestDTO);
         post.setUser(user);
         post.setTopic(topic);
@@ -67,6 +69,7 @@ public class PostService {
 
     @Transactional (readOnly = true)
     public PostResponseDTO getPostById(Long id) {
+        // retrieve post or throw exception if not found
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new PostNotFoundException("Post not found!"));
         return postMapper.toPostResponseDTO(post);
@@ -74,6 +77,7 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public List<PostResponseDTO> getPostsForUserTopics(String username) {
+        // fetch user by username or email
         User user = userRepository.findByUsernameOrEmail(username, username)
                 .orElseThrow(() -> new UserNotFoundException("User not found!"));
 

--- a/back/src/main/java/com/openclassrooms/mddapi/service/UserService.java
+++ b/back/src/main/java/com/openclassrooms/mddapi/service/UserService.java
@@ -39,6 +39,7 @@ public class UserService {
 
     @Transactional
     public void registerUser(RegisterRequestDTO registerRequestDTO) {
+        // check uniqueness of username/email and encode password before saving new user
         if (userRepository.existsByUsername(registerRequestDTO.getUsername())) {
             throw new DuplicateFieldValidationException("Username is already in use");
         }
@@ -81,6 +82,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserDTO getUserByCredential(String credential) {
+        // retrieve user by username or email
         User user = userRepository.findByUsernameOrEmail(credential, credential)
                 .orElseThrow(() -> new UserNotFoundException("User not found"));
         return userMapper.toUserDTO(user);
@@ -92,6 +94,8 @@ public class UserService {
                 .orElseThrow(() -> new UserNotFoundException("User not found"));
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new TopicNotFoundException("Topic not found"));
+
+        // add topic subscription if not already subscribed
         if (!user.getTopics().contains(topic)) {
             user.getTopics().add(topic);
             userRepository.save(user);
@@ -104,6 +108,8 @@ public class UserService {
                 .orElseThrow(() -> new UserNotFoundException("User not found"));
         Topic topic = topicRepository.findById(topicId)
                 .orElseThrow(() -> new TopicNotFoundException("Topic not found"));
+
+        // remove topic subscription if currently subscribed
         if (user.getTopics().contains(topic)) {
             user.getTopics().remove(topic);
             userRepository.save(user);


### PR DESCRIPTION
- Update PostRepository to use existsByTitle for global duplicate post title checks
- Modify PostService to validate post titles across all topics, instead of only within a single topic
- Add clarifying comments to services, repositories, models, and mappers