### PR TITLE
fix(front): show public navbar for NotFoundComponent and use esbuild for faster dev builds

### DIFF
--- a/front/angular.json
+++ b/front/angular.json
@@ -15,7 +15,7 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:browser-esbuild",
           "options": {
             "outputPath": "dist/front",
             "index": "src/index.html",

--- a/front/src/app/app-routing.module.ts
+++ b/front/src/app/app-routing.module.ts
@@ -26,7 +26,8 @@ const routes: Routes = [
   { path: 'me', component: MeComponent, canActivate: [authGuard] },
 
   // route not found
-  { path: '**', component: NotFoundComponent }
+  { path: '404', component: NotFoundComponent },
+  { path: '**', redirectTo: '/404' }
 ];
 
 @NgModule({

--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent {
 
   // check if the current page is a public route
   isPublicRoute(): boolean {
-    return ['/login', '/register'].includes(this.currentRoute);
+    return ['/login', '/register', '/404'].includes(this.currentRoute);
   }
 
   // logout user and redirect to homepage


### PR DESCRIPTION
- Prevent logged-out users from accessing the logged-in navbar via a wildcard URL
- Add '/404' route for NotFoundComponent and redirect all unknown URLs ('**') to '/404'
- Update isPublicRoute() in AppComponent to include '/404' so navbar shows correctly
- Update angular.json build builder to use esbuild for faster dev builds