### PR TITLE
fix(front): update AuthGuard, AuthInterceptor, and UserService to verify token

### DIFF
--- a/front/src/app/app.component.ts
+++ b/front/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { AuthService } from 'src/app/features/auth/services/auth.service';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
+  title = 'front'; 
   currentRoute = ''; // store current route path
 
   // capture the drawer from template

--- a/front/src/app/core/guards/auth.guard.ts
+++ b/front/src/app/core/guards/auth.guard.ts
@@ -1,16 +1,23 @@
 import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { TokenService } from '../services/token.service';
+import { UserService } from '../../features/user/services/user.service';
+import { catchError, map, of } from 'rxjs';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const tokenService = inject(TokenService);
+  const userService = inject(UserService);
   const router = inject(Router);
 
   const token = tokenService.getToken();
 
-  if (token) {
-    return true; // allow route activation if token exists
-  } else {
-    return router.createUrlTree(['/login']); // redirect to login if token is missing
+  if (!token) {
+    return router.createUrlTree(['/login']); // navigate to login if no token
   }
+
+  // verify token validity
+  return userService.getCurrentUser().pipe(
+    map(() => true), // allow route activation if token is valid
+    catchError(() => of(router.createUrlTree(['/login']))) // navigate to login if not
+  );
 };

--- a/front/src/app/core/interceptors/auth.interceptor.ts
+++ b/front/src/app/core/interceptors/auth.interceptor.ts
@@ -2,12 +2,19 @@ import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpErrorResponse } from '@angular/common/http';
 import { Observable, catchError, throwError } from 'rxjs';
 import { TokenService } from '../services/token.service';
+import { AuthService } from '../../features/auth/services/auth.service';
+import { SnackbarService } from '../../shared/services/snackbar.service';
 import { Router } from '@angular/router';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
 
-  constructor(private tokenService: TokenService, private router: Router) { }
+  constructor(
+    private tokenService: TokenService, 
+    private authService: AuthService, 
+    private snackbarService: SnackbarService,
+    private router: Router
+  ) { }
 
   intercept<T>(req: HttpRequest<T>, next: HttpHandler): Observable<HttpEvent<T>> {
     const token = this.tokenService.getToken();
@@ -24,10 +31,13 @@ export class AuthInterceptor implements HttpInterceptor {
     }
 
     return next.handle(request).pipe(
-      // handle 401 errors globally by removing token and redirecting to login
+      // handle 401 errors globally by cleaning up data and redirecting to login
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401) {
-          this.tokenService.removeToken();
+        if (error.status === 401 && !excludedEndpoints.includes(url.pathname)) {
+          setTimeout(() => { // timeout needed to show snackbar error
+            this.snackbarService.showError('Session expirée. Veuillez vous reconnecter.');
+          }, 0);
+          this.authService.logout(); // remove token, clear cached user, reset localStorage
           this.router.navigate(['/login']);
         }
         return throwError(() => error);

--- a/front/src/app/features/auth/services/auth.service.ts
+++ b/front/src/app/features/auth/services/auth.service.ts
@@ -5,13 +5,17 @@ import { RegisterRequestDTO } from '../interfaces/register-request-dto';
 import { AuthResponse } from '../interfaces/auth-response';
 import { LoginRequestDTO } from '../interfaces/login-request-dto';
 import { TokenService } from '../../../core/services/token.service';
+import { UserService } from '../../../features/user/services/user.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 	private baseUrl = '/api/auth';
 
-	constructor(private http: HttpClient, 
-				private tokenService: TokenService) { }
+	constructor(
+    private http: HttpClient, 
+    private tokenService: TokenService,
+    private userService: UserService
+  ) { }
 
 	public register(registerRequest: RegisterRequestDTO): Observable<AuthResponse> {
 		return this.http.post<AuthResponse>(`${this.baseUrl}/register`, registerRequest)
@@ -19,6 +23,7 @@ export class AuthService {
         tap(response => {
           // save token after successful registration
           this.tokenService.saveToken(response.token);
+          this.userService.clearCache(); // reset cached user data
         })
       );
 	}
@@ -29,12 +34,14 @@ export class AuthService {
         tap(response => {
           // save token after successful login
           this.tokenService.saveToken(response.token);
+          this.userService.clearCache(); // reset cached user data
         })
       );
 	}
 
 	public logout(): void {
     this.tokenService.removeToken();
+    this.userService.clearCache(); // reset cached user data
     localStorage.removeItem('postsSortOrder'); // reset sort order on logout
   }
 }

--- a/front/src/app/features/topics/components/topic-list/topic-list.component.scss
+++ b/front/src/app/features/topics/components/topic-list/topic-list.component.scss
@@ -33,6 +33,7 @@
 }
 
 .page-container {
+  min-height: calc(100vh - 160px);
   margin: 0 auto !important;
   padding: 30px !important;
 }

--- a/front/src/app/features/user/services/user.service.ts
+++ b/front/src/app/features/user/services/user.service.ts
@@ -1,18 +1,49 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { UserDTO } from '../interfaces/user-dto';
 import { UpdateUserDTO } from '../interfaces/update-user-dto';
+import { catchError, shareReplay, tap } from 'rxjs/operators';
+import { TokenService } from '../../../core/services/token.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-  constructor(private http: HttpClient) {}
+  private cachedUser$?: Observable<UserDTO>;
+
+  constructor(
+    private http: HttpClient,
+    private tokenService: TokenService
+  ) {}
 
   // fetch current user
   getCurrentUser(): Observable<UserDTO> {
-    return this.http.get<UserDTO>('/api/auth/me');
+    if (!this.tokenService.getToken()) {
+      return throwError(() => new Error('No token found.')); // throw if no token
+    }
+
+    // if user data is not cached, fetch from API
+    if (!this.cachedUser$) {
+      this.cachedUser$ = this.http.get<UserDTO>('/api/auth/me').pipe(
+        shareReplay(1), // cache the result
+        catchError(err => {
+          if (err.status === 401) {
+            // if 401, remove token and clear cache
+            this.tokenService.removeToken();
+            this.clearCache();
+          }
+          return throwError(() => err);
+        })
+      );
+    }
+
+    return this.cachedUser$;
+  }
+
+  // clear the cached current user manually
+  clearCache() {
+    this.cachedUser$ = undefined;
   }
 
   getUserById(userId: number): Observable<UserDTO> {
@@ -21,16 +52,22 @@ export class UserService {
 
   // update current user profile
   updateUser(data: UpdateUserDTO): Observable<void> {
-    return this.http.put<void>('/api/auth/me', data);
+    return this.http.put<void>('/api/auth/me', data).pipe(
+      tap(() => this.clearCache()) // refresh user data
+    );
   }
 
   // unsubscribe from a topic
   unsubscribe(topicId: number): Observable<void> {
-    return this.http.delete<void>(`/api/topics/${topicId}/subscriptions`);
+    return this.http.delete<void>(`/api/topics/${topicId}/subscriptions`).pipe(
+      tap(() => this.clearCache()) // refresh user data
+    );
   }
 
   // subscribe to a topic
   subscribe(topicId: number): Observable<void> {
-    return this.http.post<void>(`/api/topics/${topicId}/subscriptions`, {});
+    return this.http.post<void>(`/api/topics/${topicId}/subscriptions`, {}).pipe(
+      tap(() => this.clearCache()) // refresh user data
+    );
   }
 }


### PR DESCRIPTION
- Rework AuthGuard, AuthInterceptor, and UserService to ensure only backend-issued tokens are accepted
- Add caching in UserService to reduce repeated requests to the /me endpoint
- Show a snackbar when the user is redirected to login due to invalid or expired token
- Clear cached user data in AuthService on register, login, and logout