### PR TITLE
fix(front): show snackbar when token is missing and clear localStorage on logout

### DIFF
--- a/front/src/app/core/guards/auth.guard.ts
+++ b/front/src/app/core/guards/auth.guard.ts
@@ -2,16 +2,20 @@ import { CanActivateFn, Router } from '@angular/router';
 import { inject } from '@angular/core';
 import { TokenService } from '../services/token.service';
 import { UserService } from '../../features/user/services/user.service';
+import { SnackbarService } from '../../shared/services/snackbar.service';
 import { catchError, map, of } from 'rxjs';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const tokenService = inject(TokenService);
   const userService = inject(UserService);
+  const snackbarService = inject(SnackbarService);
   const router = inject(Router);
 
   const token = tokenService.getToken();
 
   if (!token) {
+    snackbarService.showError('Session expirée. Veuillez vous reconnecter.');
+    localStorage.clear(); // clear lingering orphaned token
     return router.createUrlTree(['/login']); // navigate to login if no token
   }
 

--- a/front/src/app/features/auth/services/auth.service.ts
+++ b/front/src/app/features/auth/services/auth.service.ts
@@ -42,6 +42,6 @@ export class AuthService {
 	public logout(): void {
     this.tokenService.removeToken();
     this.userService.clearCache(); // reset cached user data
-    localStorage.removeItem('postsSortOrder'); // reset sort order on logout
+    localStorage.clear(); // remove all locally stored user data
   }
 }


### PR DESCRIPTION
- Show snackbar in AuthGuard when token is missing entirely
- Clear localStorage on logout in AuthService and in AuthGuard to remove orphaned tokens
- Malformed tokens are already handled correctly